### PR TITLE
Run only one cypress spec in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,3 +5,4 @@ workflows:
   build:
     jobs:
       - cypress/run
+        spec: cypress/integration/mirror_spec.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ workflows:
   build:
     jobs:
       - cypress/run:
-        spec: cypress/integration/mirror_spec.js
+          spec: cypress/integration/mirror_spec.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,5 +4,5 @@ orbs:
 workflows:
   build:
     jobs:
-      - cypress/run
+      - cypress/run:
         spec: cypress/integration/mirror_spec.js


### PR DESCRIPTION
Added a `spec` parameter to `.circleci/config.yml` so we do not run the bonus spec in our automation.
[Circle's docs on the cypress orb `run` job](https://circleci.com/developer/orbs/orb/cypress-io/cypress#usage-examples) seem to suggest you can do it this way.