### PR TITLE
Handle cypress artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,3 +6,8 @@ workflows:
     jobs:
       - cypress/run:
           spec: cypress/integration/mirror_spec.js
+          post-steps:
+            - store_artifacts:
+                path: cypress/videos
+            - store_artifacts:
+                path: cypress/screenshots

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+.DS_Store
+cypress/videos
+cypress/screenshots


### PR DESCRIPTION
- Store screenshots and videos in CircleCI so we can more quickly see why tests failed and provide feedback.
- Add screenshots and videos to `.gitignore`. `cypress open` does not generate them but `cypress run` does (on the off chance that people use that command locally)