### PR TITLE
Simplify lab to avoid requiring knowledge of events

### DIFF
--- a/cypress/integration/bonus_spec.js
+++ b/cypress/integration/bonus_spec.js
@@ -1,23 +1,23 @@
-describe("Bonus: Vowel Remover", () => {
-  it("removes vowels excluding y when the checkbox is not checked", () => {
-    cy.get("#vowel-remover-input")
+describe('Bonus: Vowel Remover', () => {
+  it('removes vowels excluding y when the checkbox is not checked', () => {
+    cy.get('#vowel-remover-input')
       .clear()
-      .type("happy days ahead")
-      .get("#vowel-remover-form button")
+      .type('happy days ahead')
+      .get('#vowel-remover-button')
       .click()
-      .get("#vowel-remover-output")
-      .contains("hppy dys hd");
+      .get('#vowel-remover-output')
+      .contains('hppy dys hd');
   });
 
-  it("removes vowels including y when the checkbox is checked", () => {
-    cy.get("#vowel-remover-input")
+  it('removes vowels including y when the checkbox is checked', () => {
+    cy.get('#vowel-remover-input')
       .clear()
-      .type("happy days ahead")
-      .get("#y-is-vowel-checkbox")
+      .type('happy days ahead')
+      .get('#y-is-vowel-checkbox')
       .click()
-      .get("#vowel-remover-form button")
+      .get('#vowel-remover-button')
       .click()
-      .get("#vowel-remover-output")
-      .contains("hpp ds hd");
+      .get('#vowel-remover-output')
+      .contains('hpp ds hd');
   });
 });

--- a/cypress/integration/mirror_spec.js
+++ b/cypress/integration/mirror_spec.js
@@ -1,99 +1,99 @@
-describe("Mirror-spec", () => {
-  describe("1. String Mirror", () => {
-    it("mirrors the entered string", () => {
-      cy.get("#mirror-input")
+describe('Mirror-spec', () => {
+  describe('1. String Mirror', () => {
+    it('mirrors the entered string', () => {
+      cy.get('#mirror-input')
         .clear()
-        .type("Hello world!")
-        .get("#mirror-form button")
+        .type('Hello world!')
+        .get('#mirror-button')
         .click()
-        .get("#mirror-output")
-        .contains("Hello world!");
+        .get('#mirror-output')
+        .contains('Hello world!');
     });
   });
 
-  describe("2. String Uppercaser", () => {
-    it("uppercases the entered string", () => {
-      cy.get("#uppercaser-input")
+  describe('2. String Uppercaser', () => {
+    it('uppercases the entered string', () => {
+      cy.get('#uppercaser-input')
         .clear()
-        .type("Hello world!")
-        .get("#uppercaser-form button")
+        .type('Hello world!')
+        .get('#uppercaser-button')
         .click()
-        .get("#uppercaser-output")
-        .contains("HELLO WORLD!");
+        .get('#uppercaser-output')
+        .contains('HELLO WORLD!');
     });
   });
 
-  describe("3. Palindrome Detector", () => {
-    it("displays true when the string is a palindrome", () => {
-      cy.get("#palindrome-input")
+  describe('3. Palindrome Detector', () => {
+    it('displays true when the string is a palindrome', () => {
+      cy.get('#palindrome-input')
         .clear()
-        .type("tacocat")
-        .get("#palindrome-form button")
+        .type('tacocat')
+        .get('#palindrome-button')
         .click()
-        .get("#palindrome-output")
-        .contains("It is true that tacocat is a palindrome");
+        .get('#palindrome-output')
+        .contains('It is true that tacocat is a palindrome');
     });
 
-    it("displays false when the string is not a palindrome", () => {
-      cy.get("#palindrome-input")
+    it('displays false when the string is not a palindrome', () => {
+      cy.get('#palindrome-input')
         .clear()
-        .type("nachodog")
-        .get("#palindrome-form button")
+        .type('nachodog')
+        .get('#palindrome-button')
         .click()
-        .get("#palindrome-output")
-        .contains("It is false that nachodog is a palindrome");
-    });
-  });
-
-  describe("4. Even Checker", () => {
-    it("displays true when the number is even", () => {
-      cy.get("#even-checker-input")
-        .clear()
-        .type("42")
-        .get("#even-checker-form button")
-        .click()
-        .get("#even-checker-output")
-        .contains("It is true that 42 is even");
-    });
-
-    it("displays false when the number is even", () => {
-      cy.get("#even-checker-input")
-        .clear()
-        .type("117")
-        .get("#even-checker-form button")
-        .click()
-        .get("#even-checker-output")
-        .contains("It is false that 117 is even");
+        .get('#palindrome-output')
+        .contains('It is false that nachodog is a palindrome');
     });
   });
 
-  describe("5. Number Doubler", () => {
-    it("displays the number doubled", () => {
-      cy.get("#doubler-input")
+  describe('4. Even Checker', () => {
+    it('displays true when the number is even', () => {
+      cy.get('#even-checker-input')
         .clear()
-        .type("12")
-        .get("#doubler-form button")
+        .type('42')
+        .get('#even-checker-button')
         .click()
-        .get("#doubler-output")
-        .contains("12 doubled is 24");
+        .get('#even-checker-output')
+        .contains('It is true that 42 is even');
+    });
+
+    it('displays false when the number is even', () => {
+      cy.get('#even-checker-input')
+        .clear()
+        .type('117')
+        .get('#even-checker-button')
+        .click()
+        .get('#even-checker-output')
+        .contains('It is false that 117 is even');
     });
   });
 
-  describe("6. Average of Three Numbers", () => {
-    it("displays the average", () => {
-      cy.get("#average-input-1")
+  describe('5. Number Doubler', () => {
+    it('displays the number doubled', () => {
+      cy.get('#doubler-input')
         .clear()
-        .type("10")
-        .get("#average-input-2")
-        .clear()
-        .type("35")
-        .get("#average-input-3")
-        .clear()
-        .type("45")
-        .get("#average-form button")
+        .type('12')
+        .get('#doubler-button')
         .click()
-        .get("#average-output")
-        .contains("The average of 10, 35, and 45 is 30");
+        .get('#doubler-output')
+        .contains('12 doubled is 24');
+    });
+  });
+
+  describe('6. Average of Three Numbers', () => {
+    it('displays the average', () => {
+      cy.get('#average-input-1')
+        .clear()
+        .type('10')
+        .get('#average-input-2')
+        .clear()
+        .type('35')
+        .get('#average-input-3')
+        .clear()
+        .type('45')
+        .get('#average-button')
+        .click()
+        .get('#average-output')
+        .contains('The average of 10, 35, and 45 is 30');
     });
   });
 });

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <h2>3. Palindrome Detector</h2>
 
     <li>The user should be able to enter a string into a text input with id='palindrome-input'</li>
-    <li>They should then be able to click a "submit" button with id='palindrone-button'. Clicking the button will display a string in the form "It is ${true/false} that ${entered string} is a palindrome" with id='palindrome-output'</li>
+    <li>They should then be able to click a "submit" button with id='palindrome-button'. Clicking the button will display a string in the form "It is ${true/false} that ${entered string} is a palindrome" with id='palindrome-output'</li>
 
     <h2>4. Even Checker</h2>
 

--- a/index.html
+++ b/index.html
@@ -10,53 +10,44 @@
     <h2>1. String Mirror</h2>
 
     <ul>
-      <li>Make a form with id='mirror-form'</li>
-      <li>The user should be able to enter a string into a text input with id='mirror-input'</li>
+      <li>Make a text input with id='mirror-input' and a button with id='mirror-button'</li>
       <li>They should then be able to click a "submit" button that will display the string the user entered in an element with id='mirror-output'</li>
     </ul>    
 
-    <form id="mirror-form">
-      <input id="mirror-input" type="text" placeholder="Enter your string here">
-      <p id="mirror-output">Waiting for input...</p>
-      <button type="submit">Submit</button>
-    </form>
+    <input id="mirror-input" type="text" placeholder="Enter your string here">
+    <p id="mirror-output">Waiting for input...</p>
+    <button id="mirror-button" type="submit">Submit</button>
 
     <h2>2. String Uppercaser</h2>
 
-    <li>Make a form with id='uppercaser-form'</li>
-    <li>The user should be able to enter a string into a text input with id='uppercaser-input'</li>
-    <li>They should then be able to click a "submit" button that will display the string the user entered in all uppercase in an element with id='uppercaser-output'</li>
+    <li>Make a text input with id='uppercaser-input'</li>
+    <li>They should then be able to click a "submit" button with id='uppercaser-button' that will display the string the user entered in all uppercase in an element with id='uppercaser-output'</li>
 
     <h2>3. Palindrome Detector</h2>
 
-    <li>Make a form with id='palindrome-form'</li>
     <li>The user should be able to enter a string into a text input with id='palindrome-input'</li>
-    <li>They should then be able to click a "submit" button that will display a string in the form "It is ${true/false} that ${entered string} is a palindrome" with id='palindrome-output'</li>
+    <li>They should then be able to click a "submit" button with id='palindrone-button'. Clicking the button will display a string in the form "It is ${true/false} that ${entered string} is a palindrome" with id='palindrome-output'</li>
 
     <h2>4. Even Checker</h2>
 
-    <li>Make a form with id='even-checker-form'</li>
     <li>The user should be able to enter a number into an input with id='even-checker-input'</li>
-    <li>They should then be able to click a "submit" button that will display a string in the form "It is ${true/false} that ${entered number} is even" with id='even-checker-output'</li>
+    <li>They should then be able to click a "submit" button with id='even-checker-button' that will display a string in the form "It is ${true/false} that ${entered number} is even" with id='even-checker-output'</li>
 
     <h2>5. Number Doubler</h2>
 
-    <li>Make a form with id='doubler-form'</li>
     <li>The user should be able to enter a number into an input with id='doubler-input'</li>
-    <li>They should then be able to click a "submit" button that will display a string in the form "${entered number} doubled is ${doubledVal}" with id='doubler-output'</li>
+    <li>They should then be able to click a "submit" button with id='doubler-button' that will display a string in the form "${entered number} doubled is ${doubledVal}" with id='doubler-output'</li>
 
     <h2>6. Average of Three Numbers</h2>
 
-    <li>Make a form with id='average-form'</li>
-    <li>The user should be able to enter 3 numbers into text inputs with ids 'average-input-1', 'average-input-2', and 'average-input-3</li>
-    <li>They should then be able to click a "submit" button that will display a string in the form "The average of ${numberOne}, ${numberTwo}, and ${numberThree} is ${average}" with id='average-output'</li>
+    <li>The user should be able to enter 3 numbers into text inputs with ids 'average-input-1', 'average-input-2', and 'average-input-3'</li>
+    <li>They should then be able to click a "submit" button with id='average-button' that will display a string in the form "The average of ${numberOne}, ${numberTwo}, and ${numberThree} is ${average}" with id='average-output'</li>
 
     <h2>Bonus: Vowel Remover</h2>
     
-    <li>Make a form with id='vowel-remover-form'</li>
     <li>The user should be able to enter a string into a text input with id='vowel-remover-input'</li>
     <li>The user should be able to select or deselect a checkbox with id='y-is-vowel-checkbox'</li>
-    <li>They should then be able to click a "submit" button that will display the original string with all vowels removed with id='vowel-remover-output'. If the checkbox is checked, count y as a vowel. Otherwise, count y as a consonant.</li>
+    <li>They should then be able to click a "submit" button with id='vowel-remover-button' that will display the original string with all vowels removed with id='vowel-remover-output'. If the checkbox is checked, count y as a vowel. Otherwise, count y as a consonant.</li>
 
   </body>
 </html>


### PR DESCRIPTION
In its current form, this lab asks fellows to create `<form />` elements and then add `onclick` attributes and `<script />` tags that will allow user input in the form to appear on the page. Because of how HTML forms work by default (they cause a page reload), this will not work without implementing event listeners and `event.preventDefault()`. These topics have not been covered yet.

To address this, I propose:
- Don't ask them to use forms here, just inputs and buttons
- Some changes to the test automation to make this work by requiring fellows to set an `id` attribute for buttons (so cypress can find them)